### PR TITLE
Use icon for archive buttons

### DIFF
--- a/resources/views/attendance/alerts_course.blade.php
+++ b/resources/views/attendance/alerts_course.blade.php
@@ -33,7 +33,13 @@
                                   <td class="px-6 py-4 whitespace-nowrap">
                                       <form method="POST" action="{{ route('attendance.alerts.archive', [$course->id, $alert['student']->id]) }}">
                                           @csrf
-                                          <button type="submit" class="text-blue-600 hover:underline">Archive</button>
+                                          <button type="submit" title="Archive Alert" class="text-blue-500 hover:text-blue-700">
+                                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18v3H3z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 7h14v12H5z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l3 3 3-3m-3 3V9" />
+                                              </svg>
+                                          </button>
                                       </form>
                                   </td>
                               </tr>

--- a/resources/views/attendance/sessions_course.blade.php
+++ b/resources/views/attendance/sessions_course.blade.php
@@ -34,7 +34,13 @@
                                   <td class="px-6 py-4 whitespace-nowrap">
                                       <form method="POST" action="{{ route('attendance.sessions.archive', [$course->id, $session->id]) }}">
                                           @csrf
-                                          <button type="submit" class="text-blue-600 hover:underline">Archive</button>
+                                          <button type="submit" title="Archive Session" class="text-blue-500 hover:text-blue-700">
+                                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18v3H3z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 7h14v12H5z" />
+                                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l3 3 3-3m-3 3V9" />
+                                              </svg>
+                                          </button>
                                       </form>
                                   </td>
                               </tr>


### PR DESCRIPTION
## Summary
- replace "Archive" text with an archive icon for attendance alerts and sessions

## Testing
- `php artisan test` *(fails: `php` not found)*