### PR TITLE
Add session detail page with toggling attendance

### DIFF
--- a/resources/views/attendance/session_details.blade.php
+++ b/resources/views/attendance/session_details.blade.php
@@ -1,0 +1,60 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Attendance for {{ $course->course_title }} on {{ $session->session_date->format('M d, Y') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white shadow-sm sm:rounded-lg p-6">
+                @if(session('status'))
+                    <div class="mb-4 text-green-600 font-semibold">
+                        {{ session('status') }}
+                    </div>
+                @endif
+                @if($students->isNotEmpty())
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Student</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach($students as $student)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        {{ $student->last_name }}, {{ $student->first_name }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        @if($records->has($student->id))
+                                            Checked In
+                                        @else
+                                            Not Checked In
+                                        @endif
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <form method="POST" action="{{ route('attendance.sessions.toggle', [$course->id, $session->id, $student->id]) }}">
+                                            @csrf
+                                            <button type="submit" class="text-blue-500 hover:text-blue-700">
+                                                @if($records->has($student->id))
+                                                    Check Out
+                                                @else
+                                                    Check In
+                                                @endif
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                @else
+                    <p>No students found for this course.</p>
+                @endif
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/attendance/sessions_course.blade.php
+++ b/resources/views/attendance/sessions_course.blade.php
@@ -25,8 +25,10 @@
                       <tbody class="bg-white divide-y divide-gray-200">
                           @foreach($sessions as $session)
                               <tr>
-                                  <td class="px-6 py-4 whitespace-nowrap">
-                                      {{ $session->session_date->format('M d, Y') }}
+                              <td class="px-6 py-4 whitespace-nowrap">
+                                      <a href="{{ route('attendance.sessions.show', [$course->id, $session->id]) }}" class="text-blue-500 hover:text-blue-700">
+                                          {{ $session->session_date->format('M d, Y') }}
+                                      </a>
                                   </td>
                                   <td class="px-6 py-4 whitespace-nowrap">
                                       {{ $session->magic_word }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,8 +93,12 @@ Route::get('/attendance-sessions', [AttendanceController::class, 'sessionsIndex'
     ->name('attendance.sessions.index');
 Route::get('/attendance-sessions/{course}', [AttendanceController::class, 'sessionsForCourse'])
     ->name('attendance.sessions.course');
+Route::get('/attendance-sessions/{course}/{session}', [AttendanceController::class, 'showSession'])
+    ->name('attendance.sessions.show');
 Route::post('/attendance-sessions/{course}/{session}/archive', [AttendanceController::class, 'archiveSession'])
     ->name('attendance.sessions.archive');
+Route::post('/attendance-sessions/{course}/{session}/{student}/toggle', [AttendanceController::class, 'toggleAttendance'])
+    ->name('attendance.sessions.toggle');
 
 
 Route::get('/course/{course}/students', [StudentController::class, 'showForCourse'])


### PR DESCRIPTION
## Summary
- allow viewing session details and toggling attendance for each student
- link session dates to the new page
- wire up routes and controller methods for session details and toggling

## Testing
- `php artisan test` *(fails: `php: command not found`)*